### PR TITLE
Remove console.log in show-blogs

### DIFF
--- a/app/routes/blog_routes.js
+++ b/app/routes/blog_routes.js
@@ -82,8 +82,7 @@ router.get('/blogs/:id', requireToken, (req, res, next) => {
   // req.params.id will be set based on the `:id` in the route
   Blog.findById(req.params.id)
     .then(handle404)
-    .then((blog) => { console.log(blog) })
-    // if `findById` is succesful, respond with 200 and "blogs" JSON
+    // if `findById` is successful, respond with 200 and "blogs" JSON
     .then(blog => res.status(200).json({ blog: blog.toObject() }))
     // if an error occurs, pass it to the handler
     .catch(next)


### PR DESCRIPTION
Remove `console.log` so that the blog is returned and used by the following `then()`